### PR TITLE
qed: adjusted the {qed} environment configuration files

### DIFF
--- a/environments/qed/qed_support_files/config.mm
+++ b/environments/qed/qed_support_files/config.mm
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# (c) 1998-2022 all rights reserved
+# (c) 1998-2024 all rights reserved
 
 
 # external dependencies

--- a/environments/qed/qed_support_files/jupyter_notebook_config.py.ops
+++ b/environments/qed/qed_support_files/jupyter_notebook_config.py.ops
@@ -18,6 +18,7 @@ c.ServerProxy.servers = {
       'run',
       '-n', 'qed',
       'qed',
+      '--qed.shell=web',
       '--qed.app.nexus.services.web.address=ip4:127.0.0.1:{port}',
     ],
     'environment': {},

--- a/environments/qed/qed_support_files/mm.pfg
+++ b/environments/qed/qed_support_files/mm.pfg
@@ -1,6 +1,6 @@
 ;
 ; michael a.g. aïvázis <michael.aivazis@para-sim.com>
-; (c) 1998-2022 all rights reserved
+; (c) 1998-2024 all rights reserved
 
 mm:
     ; targets

--- a/environments/qed/qed_support_files/qed.yaml
+++ b/environments/qed/qed_support_files/qed.yaml
@@ -1,33 +1,7 @@
-# -*- pyre -*-
+# -*- yaml -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# (c) 1998-2022 all rights reserved
-​
-​
-# test data
-#qed.data: /home/jovyan/data
-​
-#L_051219:
-#    uri: "{qed.data}/ASAR_L_JOINT_FP_ID35506_LINE10_RUN02_051219_LEVEL1_RSLC_V1.3.h5"
-​
-​
-# attach them to the application
-#datasets:
-#    - asar.rslc#L_051219
-​
-​
-# overall application configuration
-qed.app:
-    # run as a web app
-    shell: web
-    # for the web server
-    nexus.services.web:
-        # pin the port for serving web content to some number in user space
-        address: ip4:0.0.0.0:8005
-​
-# configure the {web} shell
-pyre.shells.web#qed.app.shell:
-    # spawn a new browser window/tab every time the server starts?
-    auto: no
-​
+# (c) 1998-2024 all rights reserved
+
+
 # end of file


### PR DESCRIPTION
The main change is to the jupyter configuration file that installs the QED launcher shortcut: the `--shell=web` is now explicitly specified on the command line, so the daemon starts correctly whether there is a `qed` configuration file or not.

The rest are cosmetic.